### PR TITLE
Fix map display in firefox with explicit `height: 100%;` css tag for body.

### DIFF
--- a/gp2gp-dash/Pages/Map.cshtml
+++ b/gp2gp-dash/Pages/Map.cshtml
@@ -22,6 +22,7 @@
 
     <style type="text/css">
         body {
+            height: 100%;
             border: 0px;
             padding: 0px;
             margin: 0px;


### PR DESCRIPTION
EOF newline was not intentional, seems to be unavoidable in the github online editor.